### PR TITLE
World builder toggle to enable/disable use

### DIFF
--- a/WorldBuilder/Scripts/Editor/WorldBuilder.cs
+++ b/WorldBuilder/Scripts/Editor/WorldBuilder.cs
@@ -1,8 +1,10 @@
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEditor;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Object = UnityEngine.Object;
 
 namespace Wooshii.WorldBuilder
 {
@@ -96,6 +98,8 @@ namespace Wooshii.WorldBuilder
             }
         }
 
+        public static event Action<bool> OnEnableChanged;
+
         [System.Serializable]
         public struct ObjectContent
         {
@@ -113,7 +117,7 @@ namespace Wooshii.WorldBuilder
 
         private const float HANDLES_OFFSET = 5e-3f;
 
-        [SerializeField] private bool enabled;
+        [SerializeField] private static bool enabled;
 
         [SerializeField] private bool isSelectingPath = false;
 
@@ -140,6 +144,20 @@ namespace Wooshii.WorldBuilder
             }
         }
 
+        private static bool Enabled
+        {
+            get
+            {
+                return enabled;
+            }
+
+            set
+            {
+                enabled = value; 
+                OnEnableChanged?.Invoke(value);
+            }
+        }
+
         private void OnEnable()
         {
             // Assign default path
@@ -159,6 +177,17 @@ namespace Wooshii.WorldBuilder
             SceneView.duringSceneGui += OnSceneGUI;
 
             selectedIndex = -1;
+            OnEnableChanged += OnEnableChange;
+        }
+
+        private void OnDisable()
+        {
+            OnEnableChanged -= OnEnableChange;
+        }
+
+        private void OnEnableChange(bool enabled)
+        {
+            Repaint();
         }
 
         // Editor GUI
@@ -167,7 +196,7 @@ namespace Wooshii.WorldBuilder
         {
             DrawSearchSettings();
 
-            enabled = EditorGUILayout.Toggle("Enabled", enabled);
+            Enabled = EditorGUILayout.Toggle("Enabled", Enabled);
 
             EditorGUI.BeginDisabledGroup(!enabled);
 
@@ -220,6 +249,7 @@ namespace Wooshii.WorldBuilder
             }
 
             EditorGUI.EndDisabledGroup();
+
         }
 
         private void DrawSearchSettings()
@@ -305,7 +335,14 @@ namespace Wooshii.WorldBuilder
 
         private void OnSceneGUI(SceneView scene)
         {
-            if (!enabled || selectedIndex == -1)
+            if (Event.type == EventType.KeyDown && Event.keyCode == KeyCode.Space)
+            {
+                Enabled = !Enabled;
+                Event.Use();
+                return;
+            }
+
+            if (!Enabled || selectedIndex == -1)
             {
                 return;
             }

--- a/WorldBuilder/Scripts/Editor/WorldBuilder.cs
+++ b/WorldBuilder/Scripts/Editor/WorldBuilder.cs
@@ -113,6 +113,8 @@ namespace Wooshii.WorldBuilder
 
         private const float HANDLES_OFFSET = 5e-3f;
 
+        [SerializeField] private bool enabled;
+
         [SerializeField] private bool isSelectingPath = false;
 
         [SerializeField] private string assetPath;
@@ -165,6 +167,10 @@ namespace Wooshii.WorldBuilder
         {
             DrawSearchSettings();
 
+            enabled = EditorGUILayout.Toggle("Enabled", enabled);
+
+            EditorGUI.BeginDisabledGroup(!enabled);
+
             if (GUILayout.Button("Load Prefabs"))
             {
                 SearchAndCacheAssets();
@@ -212,6 +218,8 @@ namespace Wooshii.WorldBuilder
 
                 EditorGUILayout.EndScrollView();
             }
+
+            EditorGUI.EndDisabledGroup();
         }
 
         private void DrawSearchSettings()
@@ -294,9 +302,10 @@ namespace Wooshii.WorldBuilder
         }
 
         // Scene GUI
+
         private void OnSceneGUI(SceneView scene)
         {
-            if (selectedIndex == -1)
+            if (!enabled || selectedIndex == -1)
             {
                 return;
             }


### PR DESCRIPTION
This adds a toggle for enabling or disabling world builder. A checkbox toggle is added to the window & a quick toggle by pressing space when focused in the scene view. 